### PR TITLE
Suggestion: Avoid the plugin being called by com_dump

### DIFF
--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -26,6 +26,10 @@ class plgSystemDump extends JPlugin {
     function onAfterRender() {
        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
+        if($option == 'com_dump'){
+            return;
+        }
+
         // settings from config.xml
         $dumpConfig = JComponentHelper::getParams( 'com_dump' );
         $autopopup  = $dumpConfig->get( 'autopopup', 1 );


### PR DESCRIPTION
Suggestion: Avoid the plugin being called by com_dump which results infinite calls. This could for example happen if a dump() is placed in JView::display().
