### PR TITLE
Fix PHP warning in PHP 7.2

### DIFF
--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -39,7 +39,7 @@ class plgSystemDump extends JPlugin {
         $dumpConfig = JComponentHelper::getParams( 'com_dump' );
         $autopopup  = $dumpConfig->get( 'autopopup', 1 );
 
-        $userstate = $mainframe->getUserState( 'dump.nodes' );
+        $userstate = $mainframe->getUserState( 'dump.nodes', array() );
         $cnt_dumps  = count( $userstate );
 
         if( $autopopup && $cnt_dumps) {


### PR DESCRIPTION
Fixes #36:
`Warning: count(): Parameter must be an array or an object that implements Countable in /home2//domains/*/public_html/plugins/system/dump/dump.php on line 43`