### PR TITLE
Conform code to single coding style

### DIFF
--- a/src/administrator/components/com_dump/controller.php
+++ b/src/administrator/components/com_dump/controller.php
@@ -20,12 +20,12 @@ class DumpController extends JControllerLegacy
 		
 
 		// we need to add these paths so the component can work in both site and administrator
-		$this->addViewPath( JPATH_COMPONENT_ADMINISTRATOR . '/views' );
-		$this->addModelPath( JPATH_COMPONENT_ADMINISTRATOR . '/models' );
+		$this->addViewPath(JPATH_COMPONENT_ADMINISTRATOR . '/views');
+		$this->addModelPath(JPATH_COMPONENT_ADMINISTRATOR . '/models');
 
 		$document   = JFactory::getDocument();
 		// specify the type of the view (raw for dump tree in Frontend, html for admin comp)
-		if($mainframe->isSite()) 
+		if ($mainframe->isSite()) 
 		{
 			// specify the RAW format for the JDump Frontend menu link
 			$viewType   = "raw";
@@ -35,18 +35,18 @@ class DumpController extends JControllerLegacy
 			$viewType   = $document->getType();
 		}
 		// get some vars
-		$viewName	= JRequest::getCmd( 'view', 'about' );
-		$viewLayout = JRequest::getCmd( 'layout', 'default' );
+		$viewName	= JRequest::getCmd('view', 'about');
+		$viewLayout = JRequest::getCmd('layout', 'default');
 
 		// get the view & set the layout
-		$view       = $this->getView( $viewName,  $viewType);
-		$view->setLayout( $viewLayout );
+		$view       = $this->getView($viewName,  $viewType);
+		$view->setLayout($viewLayout);
 
 		// Get/Create the model
-		if ( $model = $this->getModel( $viewName ) ) 
+		if ($model = $this->getModel($viewName)) 
 		{
 			// Push the model into the view (as default)
-			$view->setModel( $model, true );
+			$view->setModel($model, true);
 		}
 
 		// Display the view

--- a/src/administrator/components/com_dump/controller.php
+++ b/src/administrator/components/com_dump/controller.php
@@ -11,39 +11,39 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 class DumpController extends JControllerLegacy{
 
-    function display($cachable = false, $urlparams = false) {
-        $mainframe = JFactory::getApplication(); 
-        $option = JRequest::getCmd('option');
-        $Itemid = JRequest::getInt('Itemid');
-        
+	function display($cachable = false, $urlparams = false) {
+		$mainframe = JFactory::getApplication(); 
+		$option = JRequest::getCmd('option');
+		$Itemid = JRequest::getInt('Itemid');
+		
 
-        // we need to add these paths so the component can work in both site and administrator
-        $this->addViewPath( JPATH_COMPONENT_ADMINISTRATOR . '/views' );
-        $this->addModelPath( JPATH_COMPONENT_ADMINISTRATOR . '/models' );
+		// we need to add these paths so the component can work in both site and administrator
+		$this->addViewPath( JPATH_COMPONENT_ADMINISTRATOR . '/views' );
+		$this->addModelPath( JPATH_COMPONENT_ADMINISTRATOR . '/models' );
 
-        $document   = JFactory::getDocument();
-        // specify the type of the view (raw for dump tree in Frontend, html for admin comp)
-        if($mainframe->isSite()) {
-            // specify the RAW format for the JDump Frontend menu link
-            $viewType   = "raw";
-        } else {
-            $viewType   = $document->getType();
-        }
-        // get some vars
-        $viewName	= JRequest::getCmd( 'view', 'about' );
-        $viewLayout = JRequest::getCmd( 'layout', 'default' );
+		$document   = JFactory::getDocument();
+		// specify the type of the view (raw for dump tree in Frontend, html for admin comp)
+		if($mainframe->isSite()) {
+			// specify the RAW format for the JDump Frontend menu link
+			$viewType   = "raw";
+		} else {
+			$viewType   = $document->getType();
+		}
+		// get some vars
+		$viewName	= JRequest::getCmd( 'view', 'about' );
+		$viewLayout = JRequest::getCmd( 'layout', 'default' );
 
-        // get the view & set the layout
-        $view       = $this->getView( $viewName,  $viewType);
-        $view->setLayout( $viewLayout );
+		// get the view & set the layout
+		$view       = $this->getView( $viewName,  $viewType);
+		$view->setLayout( $viewLayout );
 
-        // Get/Create the model
-        if ( $model = $this->getModel( $viewName ) ) {
-            // Push the model into the view (as default)
-            $view->setModel( $model, true );
-        }
+		// Get/Create the model
+		if ( $model = $this->getModel( $viewName ) ) {
+			// Push the model into the view (as default)
+			$view->setModel( $model, true );
+		}
 
-        // Display the view
-        $view->display();
-    }
+		// Display the view
+		$view->display();
+	}
 }

--- a/src/administrator/components/com_dump/controller.php
+++ b/src/administrator/components/com_dump/controller.php
@@ -9,9 +9,11 @@
  */
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
-class DumpController extends JControllerLegacy{
+class DumpController extends JControllerLegacy
+{
 
-	function display($cachable = false, $urlparams = false) {
+	function display($cachable = false, $urlparams = false) 
+	{
 		$mainframe = JFactory::getApplication(); 
 		$option = JRequest::getCmd('option');
 		$Itemid = JRequest::getInt('Itemid');
@@ -23,10 +25,13 @@ class DumpController extends JControllerLegacy{
 
 		$document   = JFactory::getDocument();
 		// specify the type of the view (raw for dump tree in Frontend, html for admin comp)
-		if($mainframe->isSite()) {
+		if($mainframe->isSite()) 
+		{
 			// specify the RAW format for the JDump Frontend menu link
 			$viewType   = "raw";
-		} else {
+		} 
+		else 
+		{
 			$viewType   = $document->getType();
 		}
 		// get some vars
@@ -38,7 +43,8 @@ class DumpController extends JControllerLegacy{
 		$view->setLayout( $viewLayout );
 
 		// Get/Create the model
-		if ( $model = $this->getModel( $viewName ) ) {
+		if ( $model = $this->getModel( $viewName ) ) 
+		{
 			// Push the model into the view (as default)
 			$view->setModel( $model, true );
 		}

--- a/src/administrator/components/com_dump/defines.php
+++ b/src/administrator/components/com_dump/defines.php
@@ -10,7 +10,7 @@
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
 $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
-$phpversion = explode( '.', phpversion() );
+$phpversion = explode('.', phpversion());
 
-define( 'DUMP_VERSION', '%%VERSION%%' );
-define( 'DUMP_URL',     JURI::root() . 'administrator/components/com_dump/' );
+define('DUMP_VERSION', '%%VERSION%%');
+define('DUMP_URL',     JURI::root() . 'administrator/components/com_dump/');

--- a/src/administrator/components/com_dump/dump.php
+++ b/src/administrator/components/com_dump/dump.php
@@ -16,7 +16,8 @@ require_once( JPATH_COMPONENT_ADMINISTRATOR . '/defines.php' );
 require_once( JPATH_COMPONENT_ADMINISTRATOR . '/controller.php' );
 
 // Require specific controller if requested
-if( $controller = JRequest::getCmd('controller') ) {
+if( $controller = JRequest::getCmd('controller') ) 
+{
 	require_once ( JPATH_COMPONENT_ADMINISTRATOR . '/controllers/' . $controller . '.php' );
 }
 

--- a/src/administrator/components/com_dump/dump.php
+++ b/src/administrator/components/com_dump/dump.php
@@ -11,14 +11,14 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 // use JPATH_COMPONENT_ADMINISTRATOR so we can use this in both site and administrator
 // Defines
-require_once( JPATH_COMPONENT_ADMINISTRATOR . '/defines.php' );
+require_once(JPATH_COMPONENT_ADMINISTRATOR . '/defines.php');
 // Require the base controller
-require_once( JPATH_COMPONENT_ADMINISTRATOR . '/controller.php' );
+require_once(JPATH_COMPONENT_ADMINISTRATOR . '/controller.php');
 
 // Require specific controller if requested
-if( $controller = JRequest::getCmd('controller') ) 
+if ($controller = JRequest::getCmd('controller')) 
 {
-	require_once ( JPATH_COMPONENT_ADMINISTRATOR . '/controllers/' . $controller . '.php' );
+	require_once (JPATH_COMPONENT_ADMINISTRATOR . '/controllers/' . $controller . '.php');
 }
 
 // Create the controller
@@ -26,6 +26,6 @@ $classname  = 'DumpController'.$controller;
 $controller = new $classname();
 
 // Perform the Request task
-$controller->execute( JRequest::getCmd( 'task' ) );
+$controller->execute(JRequest::getCmd('task'));
 
 $controller->redirect();

--- a/src/administrator/components/com_dump/dump.php
+++ b/src/administrator/components/com_dump/dump.php
@@ -17,7 +17,7 @@ require_once( JPATH_COMPONENT_ADMINISTRATOR . '/controller.php' );
 
 // Require specific controller if requested
 if( $controller = JRequest::getCmd('controller') ) {
-    require_once ( JPATH_COMPONENT_ADMINISTRATOR . '/controllers/' . $controller . '.php' );
+	require_once ( JPATH_COMPONENT_ADMINISTRATOR . '/controllers/' . $controller . '.php' );
 }
 
 // Create the controller

--- a/src/administrator/components/com_dump/dump.xml
+++ b/src/administrator/components/com_dump/dump.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.0" type="component" method="upgrade">
-    <name>Dump</name>
-    <author>Mathias Verraes</author>
-    <creationDate>%%TODAY%%</creationDate>
-    <copyright>(c) Mathias Verraes 2006 - 2012</copyright>
-    <license>GNU/GPL</license>
-    <authorEmail></authorEmail>
-    <authorUrl>https://github.com/mathiasverraes/jdump</authorUrl>
-    <version>%%VERSION%%</version>
-    <description>J!Dump -- Advanced print_r and var_dump replacer with DHTML tree display.</description>
-    <files folder="components/com_dump">
-        <filename>dump.php</filename>
-        <folder>views</folder>
-    </files>
-    <administration>
-        <files folder="administrator/components/com_dump">
-            <filename>config.xml</filename>
-            <filename>controller.php</filename>
-            <filename>defines.php</filename>
-            <filename>dump.php</filename>
-            <filename>helper.php</filename>
-            <filename>node.php</filename>
+	<name>Dump</name>
+	<author>Mathias Verraes</author>
+	<creationDate>%%TODAY%%</creationDate>
+	<copyright>(c) Mathias Verraes 2006 - 2012</copyright>
+	<license>GNU/GPL</license>
+	<authorEmail></authorEmail>
+	<authorUrl>https://github.com/mathiasverraes/jdump</authorUrl>
+	<version>%%VERSION%%</version>
+	<description>J!Dump -- Advanced print_r and var_dump replacer with DHTML tree display.</description>
+	<files folder="components/com_dump">
+		<filename>dump.php</filename>
+		<folder>views</folder>
+	</files>
+	<administration>
+		<files folder="administrator/components/com_dump">
+			<filename>config.xml</filename>
+			<filename>controller.php</filename>
+			<filename>defines.php</filename>
+			<filename>dump.php</filename>
+			<filename>helper.php</filename>
+			<filename>node.php</filename>
 			<filename>sysinfo.php</filename>
 
-            <folder>assets</folder>
-            <folder>models</folder>
-            <folder>views</folder>
-        </files>
-        <menu>J!Dump</menu>
-    </administration>
+			<folder>assets</folder>
+			<folder>models</folder>
+			<folder>views</folder>
+		</files>
+		<menu>J!Dump</menu>
+	</administration>
 </extension>

--- a/src/administrator/components/com_dump/helper.php
+++ b/src/administrator/components/com_dump/helper.php
@@ -11,8 +11,10 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 
 class DumpHelper extends JObject {
+	
 
-	static function showPopup() {
+	static function showPopup() 
+	{
 		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
 		jimport( 'joomla.application.helper' );
@@ -105,10 +107,12 @@ class DumpHelper extends JObject {
 				return $path;
 		}
 
-	static function & getMaxDepth() {
+	static function & getMaxDepth() 
+	{
 		static $maxdepth = null;
 
-		if ( !$maxdepth ) {
+		if ( !$maxdepth ) 
+		{
 			$dumpConfig         = JComponentHelper::getParams( 'com_dump' );
 			$maxdepth           = intval( $dumpConfig->get( 'maxdepth', 5 ) );
 			if( $maxdepth > 20 ) $maxdepth=20;

--- a/src/administrator/components/com_dump/helper.php
+++ b/src/administrator/components/com_dump/helper.php
@@ -12,63 +12,63 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 class DumpHelper extends JObject {
 
-    static function showPopup() {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+	static function showPopup() {
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-        jimport( 'joomla.application.helper' );
-        $client     = JApplicationHelper::getClientInfo($mainframe->getClientID());
+		jimport( 'joomla.application.helper' );
+		$client     = JApplicationHelper::getClientInfo($mainframe->getClientID());
 
-        // settings from config.xml
-        $dumpConfig = JComponentHelper::getParams( 'com_dump' );
-        $w          = $dumpConfig->get( 'popupwidth', 500 );
-        $h          = $dumpConfig->get( 'popupheight', 500 );
+		// settings from config.xml
+		$dumpConfig = JComponentHelper::getParams( 'com_dump' );
+		$w          = $dumpConfig->get( 'popupwidth', 500 );
+		$h          = $dumpConfig->get( 'popupheight', 500 );
 
-        // build the url
-        $url = JURI::base(true).'/index.php?option=com_dump&view=tree&format=raw';
+		// build the url
+		$url = JURI::base(true).'/index.php?option=com_dump&view=tree&format=raw';
 
-        /* @TODO remove this and implement this in a later version using JRoute
-        // only add Itemid in Site
-        if ( $mainframe->isSite() ) {
-            $url .= '&Itemid=' . DumpHelper::getComponentItemid( 'com_dump' );
-        }
-        */
+		/* @TODO remove this and implement this in a later version using JRoute
+		// only add Itemid in Site
+		if ( $mainframe->isSite() ) {
+			$url .= '&Itemid=' . DumpHelper::getComponentItemid( 'com_dump' );
+		}
+		*/
 
-        // create the javascript
-        // We can't use $document, because it's already rendered
-        $nl = "\n";
-        $script = $nl. '<!-- J!Dump -->' .$nl.
-                '<script type="text/javascript">' .$nl.
-                '// <!--' .$nl.
-                'window.open( "'.$url.'", "dump_'.$client->name.'", "height='.$h.',width='.$w.',toolbar=0,status=0,menubar=0,scrollbars=1,resizable=1");' .$nl.
-                '// -->' .$nl.
-                '</script>' .$nl.
-                '<!-- / J!Dump -->';
+		// create the javascript
+		// We can't use $document, because it's already rendered
+		$nl = "\n";
+		$script = $nl. '<!-- J!Dump -->' .$nl.
+				'<script type="text/javascript">' .$nl.
+				'// <!--' .$nl.
+				'window.open( "'.$url.'", "dump_'.$client->name.'", "height='.$h.',width='.$w.',toolbar=0,status=0,menubar=0,scrollbars=1,resizable=1");' .$nl.
+				'// -->' .$nl.
+				'</script>' .$nl.
+				'<!-- / J!Dump -->';
 
-        // add the code to the header (thanks jenscski)
-        // JResponse::appendBody( $script );
-        $body = JResponse::getBody();
-        $body = str_replace('</head>', $script.'</head>', $body);
-        JResponse::setBody($body);
+		// add the code to the header (thanks jenscski)
+		// JResponse::appendBody( $script );
+		$body = JResponse::getBody();
+		$body = str_replace('</head>', $script.'</head>', $body);
+		JResponse::setBody($body);
 
-    }
+	}
 
 /* @TODO remove this and implement this in a later version using JRoute
-    function getComponentItemid( $option ) {
-        jimport('joomla.application.menu');
-        $menu = JMenu::getInstance();
-        $components = $menu->getItems( 'type', 'component' );
+	function getComponentItemid( $option ) {
+		jimport('joomla.application.menu');
+		$menu = JMenu::getInstance();
+		$components = $menu->getItems( 'type', 'component' );
 
-        $attribs['option'] = '';
-        foreach( $components as $component ) {
-            $str = str_replace( 'index.php?', '', $component->link );
-            parse_str( $str, $attribs );
-            if( $attribs['option'] == $option ){
-                return $component->id;
-            }
-        }
-        // if no Itemid is found (because there's no menuitem for $option), return current
-        return $GLOBALS['Itemid'];
-    }
+		$attribs['option'] = '';
+		foreach( $components as $component ) {
+			$str = str_replace( 'index.php?', '', $component->link );
+			parse_str( $str, $attribs );
+			if( $attribs['option'] == $option ){
+				return $component->id;
+			}
+		}
+		// if no Itemid is found (because there's no menuitem for $option), return current
+		return $GLOBALS['Itemid'];
+	}
 */
 
 
@@ -100,21 +100,21 @@ class DumpHelper extends JObject {
 				$path = 'File: '.str_replace(JPATH_BASE.'/', '', $trace[0]['file'])
 				. '<br />'
 				. 'Line: '.$trace[0]['line']
-                . '<br />';
+				. '<br />';
 
 				return $path;
 		}
 
-    static function & getMaxDepth() {
-        static $maxdepth = null;
+	static function & getMaxDepth() {
+		static $maxdepth = null;
 
-        if ( !$maxdepth ) {
-            $dumpConfig         = JComponentHelper::getParams( 'com_dump' );
-            $maxdepth           = intval( $dumpConfig->get( 'maxdepth', 5 ) );
-            if( $maxdepth > 20 ) $maxdepth=20;
-            if( $maxdepth < 1  ) $maxdepth=1;
-        }
+		if ( !$maxdepth ) {
+			$dumpConfig         = JComponentHelper::getParams( 'com_dump' );
+			$maxdepth           = intval( $dumpConfig->get( 'maxdepth', 5 ) );
+			if( $maxdepth > 20 ) $maxdepth=20;
+			if( $maxdepth < 1  ) $maxdepth=1;
+		}
 
-        return $maxdepth;
-    }
+		return $maxdepth;
+	}
 }

--- a/src/administrator/components/com_dump/helper.php
+++ b/src/administrator/components/com_dump/helper.php
@@ -11,19 +11,19 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 
 class DumpHelper extends JObject {
-	
+
 
 	static function showPopup() 
 	{
 		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-		jimport( 'joomla.application.helper' );
+		jimport('joomla.application.helper');
 		$client     = JApplicationHelper::getClientInfo($mainframe->getClientID());
 
 		// settings from config.xml
 		$dumpConfig = JComponentHelper::getParams( 'com_dump' );
-		$w          = $dumpConfig->get( 'popupwidth', 500 );
-		$h          = $dumpConfig->get( 'popupheight', 500 );
+		$w          = $dumpConfig->get('popupwidth', 500);
+		$h          = $dumpConfig->get('popupheight', 500);
 
 		// build the url
 		$url = JURI::base(true).'/index.php?option=com_dump&view=tree&format=raw';
@@ -111,12 +111,12 @@ class DumpHelper extends JObject {
 	{
 		static $maxdepth = null;
 
-		if ( !$maxdepth ) 
+		if (!$maxdepth) 
 		{
-			$dumpConfig         = JComponentHelper::getParams( 'com_dump' );
-			$maxdepth           = intval( $dumpConfig->get( 'maxdepth', 5 ) );
-			if( $maxdepth > 20 ) $maxdepth=20;
-			if( $maxdepth < 1  ) $maxdepth=1;
+			$dumpConfig         = JComponentHelper::getParams('com_dump');
+			$maxdepth           = intval($dumpConfig->get('maxdepth', 5));
+			if( $maxdepth > 20 ) $maxdepth = 20;
+			if( $maxdepth < 1  ) $maxdepth = 1;
 		}
 
 		return $maxdepth;

--- a/src/administrator/components/com_dump/models/tree.php
+++ b/src/administrator/components/com_dump/models/tree.php
@@ -10,28 +10,28 @@
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
 class DumpModelTree extends JModelLegacy {
-    var $_nodes = array();
+	var $_nodes = array();
 
-    function __construct() {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+	function __construct() {
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-        //get the userstate
-        $this->_nodes = $mainframe->getUserState( 'dump.nodes' );
-        if ( !is_array( $this->_nodes ) ) {
-            $this->_nodes = array();
-        }
-        // and clear it
-        $mainframe->setUserState( 'dump.nodes', array() );
+		//get the userstate
+		$this->_nodes = $mainframe->getUserState( 'dump.nodes' );
+		if ( !is_array( $this->_nodes ) ) {
+			$this->_nodes = array();
+		}
+		// and clear it
+		$mainframe->setUserState( 'dump.nodes', array() );
 
-        parent::__construct();
+		parent::__construct();
 
-    }
+	}
 
-    function & getNodes() {
-        return $this->_nodes;
-    }
+	function & getNodes() {
+		return $this->_nodes;
+	}
 
-    function countDumps() {
-        return count( $this->_nodes ) ;
-    }
+	function countDumps() {
+		return count( $this->_nodes ) ;
+	}
 }

--- a/src/administrator/components/com_dump/models/tree.php
+++ b/src/administrator/components/com_dump/models/tree.php
@@ -9,15 +9,18 @@
  */
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
-class DumpModelTree extends JModelLegacy {
+class DumpModelTree extends JModelLegacy 
+{
 	var $_nodes = array();
 
-	function __construct() {
+	function __construct() 
+	{
 		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
 		//get the userstate
 		$this->_nodes = $mainframe->getUserState( 'dump.nodes' );
-		if ( !is_array( $this->_nodes ) ) {
+		if ( !is_array( $this->_nodes ) ) 
+		{
 			$this->_nodes = array();
 		}
 		// and clear it
@@ -27,11 +30,13 @@ class DumpModelTree extends JModelLegacy {
 
 	}
 
-	function & getNodes() {
+	function & getNodes() 
+	{
 		return $this->_nodes;
 	}
 
-	function countDumps() {
+	function countDumps() 
+	{
 		return count( $this->_nodes ) ;
 	}
 }

--- a/src/administrator/components/com_dump/models/tree.php
+++ b/src/administrator/components/com_dump/models/tree.php
@@ -18,13 +18,13 @@ class DumpModelTree extends JModelLegacy
 		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
 		//get the userstate
-		$this->_nodes = $mainframe->getUserState( 'dump.nodes' );
-		if ( !is_array( $this->_nodes ) ) 
+		$this->_nodes = $mainframe->getUserState('dump.nodes');
+		if (!is_array($this->_nodes)) 
 		{
 			$this->_nodes = array();
 		}
 		// and clear it
-		$mainframe->setUserState( 'dump.nodes', array() );
+		$mainframe->setUserState('dump.nodes', array());
 
 		parent::__construct();
 

--- a/src/administrator/components/com_dump/node.php
+++ b/src/administrator/components/com_dump/node.php
@@ -11,65 +11,65 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 class DumpNode {
 
-    static function & getNode( $var, $name, $type = null, $level = 0, $source = null ) {
+	static function & getNode( $var, $name, $type = null, $level = 0, $source = null ) {
 
-        $node['name']       = $name;
-        $node['type']       = strtolower( $type ? $type : gettype( $var ) );
-        $node['children']   = array();
-        $node['level']      = $level;
+		$node['name']       = $name;
+		$node['type']       = strtolower( $type ? $type : gettype( $var ) );
+		$node['children']   = array();
+		$node['level']      = $level;
 				$node['source']     = $source;
 
-        // expand the var according to type
-        switch ( $node['type'] ) {
+		// expand the var according to type
+		switch ( $node['type'] ) {
 			case 'backtrace': // Skip source when backtrace, and change to array
 				$node['source'] = null;
 				$node['type']   = 'array';
 
-            case 'array':
-                if ( $level >= DumpHelper::getMaxDepth() ) {
-                    $node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
-                } else {
-                	ksort($var);
-                    foreach ( $var as $key => $value ) {
-                        $node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
-                    }
-                }
-                break;
+			case 'array':
+				if ( $level >= DumpHelper::getMaxDepth() ) {
+					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
+				} else {
+					ksort($var);
+					foreach ( $var as $key => $value ) {
+						$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
+					}
+				}
+				break;
 
-            case 'object':
-                if ( $level >= DumpHelper::getMaxDepth() ) {
-                    $node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
-                } else {
-                    $object_vars = get_object_vars( $var ) ;
-                    $methods     = get_class_methods( $var ) ;
-                    if( count( $object_vars ) ) {
-                        $node['children'][] = DumpNode::getNode( $var, 'Properties', 'properties', $level );
-                    }
-                    if( count( $methods ) ) {
-                        $node['children'][] = DumpNode::getNode( $var, 'Methods', 'methods', $level );
-                    }
-                }
-                $node['classname'] = get_class( $var );
-                break;
+			case 'object':
+				if ( $level >= DumpHelper::getMaxDepth() ) {
+					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
+				} else {
+					$object_vars = get_object_vars( $var ) ;
+					$methods     = get_class_methods( $var ) ;
+					if( count( $object_vars ) ) {
+						$node['children'][] = DumpNode::getNode( $var, 'Properties', 'properties', $level );
+					}
+					if( count( $methods ) ) {
+						$node['children'][] = DumpNode::getNode( $var, 'Methods', 'methods', $level );
+					}
+				}
+				$node['classname'] = get_class( $var );
+				break;
 
-            case 'properties':
-                $object_vars = get_object_vars( $var );
-                ksort($object_vars);
-                foreach ( $object_vars as $key => $value ) {
-                    $node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
-                }
-                break;
+			case 'properties':
+				$object_vars = get_object_vars( $var );
+				ksort($object_vars);
+				foreach ( $object_vars as $key => $value ) {
+					$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
+				}
+				break;
 
-            case 'methods':
-                $methods = get_class_methods( $var ) ;
-                sort($methods);
-                foreach ( $methods as $value ) {
-                    $node['children'][] = DumpNode::getNode( null, $value, 'method' );
-                }
-                break;
+			case 'methods':
+				$methods = get_class_methods( $var ) ;
+				sort($methods);
+				foreach ( $methods as $value ) {
+					$node['children'][] = DumpNode::getNode( null, $value, 'method' );
+				}
+				break;
 
 
-            case 'string':
+			case 'string':
 				jimport( 'joomla.application.component.helper' );
 				// settings from config.xml
 				$dumpConfig		= JComponentHelper::getParams( 'com_dump' );
@@ -85,16 +85,16 @@ class DumpNode {
 					$node['length'] = $length;
 				}
 
-                $node['value']	= $var;
-                break;
+				$node['value']	= $var;
+				break;
 
-            default:
-                $node['value']        = & $var;
-                break;
+			default:
+				$node['value']        = & $var;
+				break;
 
-        }
+		}
 
-        return $node;
-    }
+		return $node;
+	}
 
 }

--- a/src/administrator/components/com_dump/node.php
+++ b/src/administrator/components/com_dump/node.php
@@ -12,91 +12,91 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 class DumpNode 
 {
 
-	static function & getNode( $var, $name, $type = null, $level = 0, $source = null ) 
+	static function & getNode($var, $name, $type = null, $level = 0, $source = null) 
 	{
 
 		$node['name']       = $name;
-		$node['type']       = strtolower( $type ? $type : gettype( $var ) );
+		$node['type']       = strtolower($type ? $type : gettype( $var ));
 		$node['children']   = array();
 		$node['level']      = $level;
 				$node['source']     = $source;
 
 		// expand the var according to type
-		switch ( $node['type'] ) 
+		switch ($node['type']) 
 		{
 			case 'backtrace': // Skip source when backtrace, and change to array
 				$node['source'] = null;
 				$node['type']   = 'array';
 
 			case 'array':
-				if ( $level >= DumpHelper::getMaxDepth() ) 
+				if ($level >= DumpHelper::getMaxDepth()) 
 				{
-					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
+					$node['children'][] = DumpNode::getNode('Maximum depth reached', null, 'message');
 				} 
 				else 
 				{
 					ksort($var);
-					foreach ( $var as $key => $value ) 
+					foreach ($var as $key => $value) 
 					{
-						$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
+						$node['children'][] = DumpNode::getNode($value, $key, null, $level + 1);
 					}
 				}
 				break;
 
 			case 'object':
-				if ( $level >= DumpHelper::getMaxDepth() ) 
+				if ($level >= DumpHelper::getMaxDepth()) 
 				{
-					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
+					$node['children'][] = DumpNode::getNode('Maximum depth reached', null, 'message');
 				} 
 				else 
 				{
-					$object_vars = get_object_vars( $var ) ;
-					$methods     = get_class_methods( $var ) ;
-					if( count( $object_vars ) ) 
+					$object_vars = get_object_vars($var) ;
+					$methods     = get_class_methods($var) ;
+					if (count($object_vars)) 
 					{
-						$node['children'][] = DumpNode::getNode( $var, 'Properties', 'properties', $level );
+						$node['children'][] = DumpNode::getNode($var, 'Properties', 'properties', $level);
 					}
-					if( count( $methods ) ) 
+					if (count($methods)) 
 					{
-						$node['children'][] = DumpNode::getNode( $var, 'Methods', 'methods', $level );
+						$node['children'][] = DumpNode::getNode($var, 'Methods', 'methods', $level);
 					}
 				}
-				$node['classname'] = get_class( $var );
+				$node['classname'] = get_class($var);
 				break;
 
 			case 'properties':
-				$object_vars = get_object_vars( $var );
+				$object_vars = get_object_vars($var);
 				ksort($object_vars);
-				foreach ( $object_vars as $key => $value ) 
+				foreach ($object_vars as $key => $value) 
 				{
-					$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
+					$node['children'][] = DumpNode::getNode($value, $key, null, $level + 1);
 				}
 				break;
 
 			case 'methods':
-				$methods = get_class_methods( $var ) ;
+				$methods = get_class_methods($var);
 				sort($methods);
-				foreach ( $methods as $value ) 
+				foreach ($methods as $value) 
 				{
-					$node['children'][] = DumpNode::getNode( null, $value, 'method' );
+					$node['children'][] = DumpNode::getNode(null, $value, 'method');
 				}
 				break;
 
 
 			case 'string':
-				jimport( 'joomla.application.component.helper' );
+				jimport('joomla.application.component.helper');
 				// settings from config.xml
-				$dumpConfig		= JComponentHelper::getParams( 'com_dump' );
-				$trimstrings	= $dumpConfig->get( 'trimstrings', 1);
-				$maxstrlength	= $dumpConfig->get( 'maxstrlength', 150);
+				$dumpConfig		= JComponentHelper::getParams('com_dump');
+				$trimstrings	= $dumpConfig->get('trimstrings', 1);
+				$maxstrlength	= $dumpConfig->get('maxstrlength', 150);
 
 				//original string length
-				$length			= JString::strlen( $var );
+				$length			= JString::strlen($var);
 
 				// trim string if needed
-				if( $trimstrings AND $length > $maxstrlength ) 
+				if ($trimstrings AND $length > $maxstrlength) 
 				{
-					$var = JString::substr( $var, 0, $maxstrlength ) . '...';
+					$var = JString::substr($var, 0, $maxstrlength) . '...';
 					$node['length'] = $length;
 				}
 
@@ -104,7 +104,7 @@ class DumpNode
 				break;
 
 			default:
-				$node['value']        = & $var;
+				$node['value'] = & $var;
 				break;
 
 		}

--- a/src/administrator/components/com_dump/node.php
+++ b/src/administrator/components/com_dump/node.php
@@ -9,9 +9,11 @@
  */
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
-class DumpNode {
+class DumpNode 
+{
 
-	static function & getNode( $var, $name, $type = null, $level = 0, $source = null ) {
+	static function & getNode( $var, $name, $type = null, $level = 0, $source = null ) 
+	{
 
 		$node['name']       = $name;
 		$node['type']       = strtolower( $type ? $type : gettype( $var ) );
@@ -20,32 +22,42 @@ class DumpNode {
 				$node['source']     = $source;
 
 		// expand the var according to type
-		switch ( $node['type'] ) {
+		switch ( $node['type'] ) 
+		{
 			case 'backtrace': // Skip source when backtrace, and change to array
 				$node['source'] = null;
 				$node['type']   = 'array';
 
 			case 'array':
-				if ( $level >= DumpHelper::getMaxDepth() ) {
+				if ( $level >= DumpHelper::getMaxDepth() ) 
+				{
 					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
-				} else {
+				} 
+				else 
+				{
 					ksort($var);
-					foreach ( $var as $key => $value ) {
+					foreach ( $var as $key => $value ) 
+					{
 						$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
 					}
 				}
 				break;
 
 			case 'object':
-				if ( $level >= DumpHelper::getMaxDepth() ) {
+				if ( $level >= DumpHelper::getMaxDepth() ) 
+				{
 					$node['children'][] = DumpNode::getNode( 'Maximum depth reached', null, 'message' );
-				} else {
+				} 
+				else 
+				{
 					$object_vars = get_object_vars( $var ) ;
 					$methods     = get_class_methods( $var ) ;
-					if( count( $object_vars ) ) {
+					if( count( $object_vars ) ) 
+					{
 						$node['children'][] = DumpNode::getNode( $var, 'Properties', 'properties', $level );
 					}
-					if( count( $methods ) ) {
+					if( count( $methods ) ) 
+					{
 						$node['children'][] = DumpNode::getNode( $var, 'Methods', 'methods', $level );
 					}
 				}
@@ -55,7 +67,8 @@ class DumpNode {
 			case 'properties':
 				$object_vars = get_object_vars( $var );
 				ksort($object_vars);
-				foreach ( $object_vars as $key => $value ) {
+				foreach ( $object_vars as $key => $value ) 
+				{
 					$node['children'][] = DumpNode::getNode( $value, $key, null, $level + 1 );
 				}
 				break;
@@ -63,7 +76,8 @@ class DumpNode {
 			case 'methods':
 				$methods = get_class_methods( $var ) ;
 				sort($methods);
-				foreach ( $methods as $value ) {
+				foreach ( $methods as $value ) 
+				{
 					$node['children'][] = DumpNode::getNode( null, $value, 'method' );
 				}
 				break;
@@ -80,7 +94,8 @@ class DumpNode {
 				$length			= JString::strlen( $var );
 
 				// trim string if needed
-				if( $trimstrings AND $length > $maxstrlength ) {
+				if( $trimstrings AND $length > $maxstrlength ) 
+				{
 					$var = JString::substr( $var, 0, $maxstrlength ) . '...';
 					$node['length'] = $length;
 				}

--- a/src/administrator/components/com_dump/sysinfo.php
+++ b/src/administrator/components/com_dump/sysinfo.php
@@ -13,56 +13,56 @@ jimport( 'joomla.utilities.array' );
 
 class DumpSysinfo extends JObject
 {
-    var $data = array();
+	var $data = array();
 
-    function __construct()
-    {
-        // execute all methods that start with '_load'
-        foreach( get_class_methods( $this ) as $method ) {
-            if( '_load' == substr( $method, 0, 5 ) ) {
-                $this->$method();
-            }
-        }
-        $this->sort( $this->data );
-    }
+	function __construct()
+	{
+		// execute all methods that start with '_load'
+		foreach( get_class_methods( $this ) as $method ) {
+			if( '_load' == substr( $method, 0, 5 ) ) {
+				$this->$method();
+			}
+		}
+		$this->sort( $this->data );
+	}
 
-    function _loadConfig()
-    {
-        $jconf                  = new JConfig();
-        $jconf->password        = '*******';
-        $jconf->ftp_pass        = '*******';
-        $jconf->secret          = '*******';
-        $this->data['Joomla Configuration'] = JArrayHelper::fromObject( $jconf );
-    }
+	function _loadConfig()
+	{
+		$jconf                  = new JConfig();
+		$jconf->password        = '*******';
+		$jconf->ftp_pass        = '*******';
+		$jconf->secret          = '*******';
+		$this->data['Joomla Configuration'] = JArrayHelper::fromObject( $jconf );
+	}
 
-    function _loadVersions()
-    {
-        $version = new JVersion();
-        $this->data['Versions']['Joomla!']        = $version->getLongVersion();
-        $this->data['Versions']['J!Dump'] = DUMP_VERSION;
-        $this->data['Versions']['PHP']            = phpversion();
-        $this->data['Versions']['Apache']         = function_exists('apache_get_version') ? apache_get_version() : 'unknown';
-        $this->data['Versions']['Zend Engine']    = zend_version();
-    }
+	function _loadVersions()
+	{
+		$version = new JVersion();
+		$this->data['Versions']['Joomla!']        = $version->getLongVersion();
+		$this->data['Versions']['J!Dump'] = DUMP_VERSION;
+		$this->data['Versions']['PHP']            = phpversion();
+		$this->data['Versions']['Apache']         = function_exists('apache_get_version') ? apache_get_version() : 'unknown';
+		$this->data['Versions']['Zend Engine']    = zend_version();
+	}
 
-    function _loadEnvironment()
-    {
-        $this->data['Environment']['_SERVER']		=  $_SERVER;
-        $this->data['Environment']['_GET']			=  $_GET;
-        $this->data['Environment']['_POST']			=  $_POST;
-        $this->data['Environment']['_COOKIE']		=  $_COOKIE;
-        $this->data['Environment']['_FILES']		=  $_FILES;
-        $this->data['Environment']['_ENV']			=  $_ENV;
-        $this->data['Environment']['_REQUEST']		=  $_REQUEST;
-    }
+	function _loadEnvironment()
+	{
+		$this->data['Environment']['_SERVER']		=  $_SERVER;
+		$this->data['Environment']['_GET']			=  $_GET;
+		$this->data['Environment']['_POST']			=  $_POST;
+		$this->data['Environment']['_COOKIE']		=  $_COOKIE;
+		$this->data['Environment']['_FILES']		=  $_FILES;
+		$this->data['Environment']['_ENV']			=  $_ENV;
+		$this->data['Environment']['_REQUEST']		=  $_REQUEST;
+	}
 
-    // recursive natural key sort
-    function sort( & $array ){
-        uksort( $array, 'strnatcasecmp' ); // this will do natural key sorting (A=a)
-        foreach( array_keys( $array ) as $k ){
-            if( 'array' == gettype( $array[$k] ) ){
-                $this->sort( $array[$k] );
-            }
-        }
-    }
+	// recursive natural key sort
+	function sort( & $array ){
+		uksort( $array, 'strnatcasecmp' ); // this will do natural key sorting (A=a)
+		foreach( array_keys( $array ) as $k ){
+			if( 'array' == gettype( $array[$k] ) ){
+				$this->sort( $array[$k] );
+			}
+		}
+	}
 }

--- a/src/administrator/components/com_dump/sysinfo.php
+++ b/src/administrator/components/com_dump/sysinfo.php
@@ -57,10 +57,13 @@ class DumpSysinfo extends JObject
 	}
 
 	// recursive natural key sort
-	function sort( & $array ){
+	function sort( & $array )
+	{
 		uksort( $array, 'strnatcasecmp' ); // this will do natural key sorting (A=a)
-		foreach( array_keys( $array ) as $k ){
-			if( 'array' == gettype( $array[$k] ) ){
+		foreach( array_keys( $array ) as $k )
+		{
+			if( 'array' == gettype( $array[$k] ) )
+			{
 				$this->sort( $array[$k] );
 			}
 		}

--- a/src/administrator/components/com_dump/sysinfo.php
+++ b/src/administrator/components/com_dump/sysinfo.php
@@ -18,8 +18,8 @@ class DumpSysinfo extends JObject
 	function __construct()
 	{
 		// execute all methods that start with '_load'
-		foreach( get_class_methods( $this ) as $method ) {
-			if( '_load' == substr( $method, 0, 5 ) ) {
+		foreach (get_class_methods($this) as $method) {
+			if ('_load' == substr($method, 0, 5)) {
 				$this->$method();
 			}
 		}
@@ -32,7 +32,7 @@ class DumpSysinfo extends JObject
 		$jconf->password        = '*******';
 		$jconf->ftp_pass        = '*******';
 		$jconf->secret          = '*******';
-		$this->data['Joomla Configuration'] = JArrayHelper::fromObject( $jconf );
+		$this->data['Joomla Configuration'] = JArrayHelper::fromObject($jconf);
 	}
 
 	function _loadVersions()
@@ -57,14 +57,14 @@ class DumpSysinfo extends JObject
 	}
 
 	// recursive natural key sort
-	function sort( & $array )
+	function sort(&$array)
 	{
-		uksort( $array, 'strnatcasecmp' ); // this will do natural key sorting (A=a)
-		foreach( array_keys( $array ) as $k )
+		uksort($array, 'strnatcasecmp'); // this will do natural key sorting (A=a)
+		foreach (array_keys($array) as $k)
 		{
-			if( 'array' == gettype( $array[$k] ) )
+			if ('array' == gettype($array[$k]))
 			{
-				$this->sort( $array[$k] );
+				$this->sort($array[$k]);
 			}
 		}
 	}

--- a/src/administrator/components/com_dump/views/about/view.html.php
+++ b/src/administrator/components/com_dump/views/about/view.html.php
@@ -9,8 +9,10 @@
  */
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
-class DumpViewAbout extends JViewLegacy {
-	function display($tpl = null) {
+class DumpViewAbout extends JViewLegacy 
+{
+	function display($tpl = null) 
+	{
 		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
 		// Toolbar

--- a/src/administrator/components/com_dump/views/about/view.html.php
+++ b/src/administrator/components/com_dump/views/about/view.html.php
@@ -10,15 +10,15 @@
 defined( '_JEXEC' ) or die( 'Restricted access' );
 
 class DumpViewAbout extends JViewLegacy {
-    function display($tpl = null) {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+	function display($tpl = null) {
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-        // Toolbar
-        JToolBarHelper::title( 'J!Dump v' . DUMP_VERSION );
-        $bar = JToolBar::getInstance('toolbar');
-        $bar->appendButton( 'Popup', 'default', 'Popup', "index.php?option=com_dump&view=tree&format=raw&closebutton=0" );
-        JToolBarHelper::preferences( 'com_dump', '300' );
+		// Toolbar
+		JToolBarHelper::title( 'J!Dump v' . DUMP_VERSION );
+		$bar = JToolBar::getInstance('toolbar');
+		$bar->appendButton( 'Popup', 'default', 'Popup', "index.php?option=com_dump&view=tree&format=raw&closebutton=0" );
+		JToolBarHelper::preferences( 'com_dump', '300' );
 
-        parent::display($tpl);
-    }
+		parent::display($tpl);
+	}
 }

--- a/src/administrator/components/com_dump/views/tree/tmpl/default.php
+++ b/src/administrator/components/com_dump/views/tree/tmpl/default.php
@@ -44,17 +44,17 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 <a href="#" onclick="window.location.reload( true );return false;" id="dumpRefresh" class="dumpRefresh">Refresh</a>
 
 <?php if( $this->closebutton ) {
-    ?><a href="#" onclick="window.close();return false;" class="dumpClose">Close Window</a><?php
+	?><a href="#" onclick="window.close();return false;" class="dumpClose">Close Window</a><?php
 } ?>
 
 <?php if( $this->tree=='' ) {
-    ?><br /><br />No dumped variables found.<br /><?php
+	?><br /><br />No dumped variables found.<br /><?php
 } else {
-    ?><a href="#" onclick="expandAll('dhtmlgoodies_tree');return false;" class="dumpExpandAll">Expand all</a>
+	?><a href="#" onclick="expandAll('dhtmlgoodies_tree');return false;" class="dumpExpandAll">Expand all</a>
 <a href="#" onclick="collapseAll('dhtmlgoodies_tree');return false;" class="dumpCollapseAll">Collapse all</a><br /><br />
 <ul id="dhtmlgoodies_tree" class="dhtmlgoodies_tree"><?php
-    echo $this->tree
-    ?></ul><?php
+	echo $this->tree
+	?></ul><?php
 }?>
 
 <br />

--- a/src/administrator/components/com_dump/views/tree/view.raw.php
+++ b/src/administrator/components/com_dump/views/tree/view.raw.php
@@ -13,262 +13,262 @@ JHTML::_('behavior.tooltip');
 
 class DumpViewTree extends JViewLegacy
 {
-    function display($tpl = null)
-    {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
-
-        // we need to add these paths so the component can work in both site and administrator
-        $this->addTemplatePath( dirname(__FILE__) . '/tmpl' );
-
-        // client information (site, administrator, ... )
-        jimport( 'joomla.application.helper' );
-        $client = JApplicationHelper::getClientInfo($mainframe->getClientID());
-
-        // make sure we only show the component
-        JRequest::setVar( 'tmpl', 'component' );
-
-        // render tree and assign to template
-        $tree = $this->renderTree();
-        $this->assignRef('tree', $tree );
-
-        $this->assignRef(	'application',	$client->name );
-        $this->assign(		'version',			DUMP_VERSION );
-        $this->assign(		'closebutton',		JRequest::getInt( 'closebutton', 1 ) );
-
-        parent::display($tpl);
-    }
-
-    function & renderTree() {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
-
-        $output = '';
-
-        // get the nodes from the model
-        $nodes = $this->get('nodes');
-
-        // render the nodes to <ul><li...
-        foreach ( $nodes as $node ) {
-            $output .= $this->renderNode( $node );
-        }
-        return $output;
-    }
-
-    function renderNode( & $node ) {
-        switch ( $node['type'] ) {
-            case 'object':
-            case 'array':
-                return $this->renderObjArray( $node );
-                break;
-            case 'integer':
-            case 'float':
-            case 'double':
-                return $this->renderNumber( $node );
-                break;
-            case 'string':
-                return $this->renderString( $node );
-                break;
-            case 'null':
-            case 'resource':
-                return $this->renderNull( $node );
-                break;
-            case 'boolean':
-                return $this->renderBoolean( $node );
-                break;
-            case 'method':
-                return $this->renderMethod( $node );
-                break;
-            case 'methods':
-            case 'properties':
-                return $this->renderMethProp( $node );
-                break;
-            case 'message':
-                return $this->renderMessage( $node );
-                break;
-            default:
-                return $this->renderObjArray( $node );
-                break;
-        }
-    }
-
-    function renderObjArray( & $node ) {
-        global $node_id;
-
-
-
-        $children = count( $node['children'] );
-
-        $output = '';
-
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="a' . ++$node_id . '">' ;
-        $output .= '<span class="dumpType"> [';
-        $output .= ( isset( $node['classname'] ) ? $node['classname'] . ' ' : '' );
-        $output .= $node['type'];
-        $output .= ']</span> ';
-
-        $output .= $node['name'];
-        $output .= $this->renderSource( $node );
-
-
-
-        $output .= $children ? '' : ' = <i>(empty)</i>';
-        $output .= '</a>';
-
-        if ( $children ) {
-            $output .= '<ul>';
-            foreach( $node['children'] as $child ) {
-                $output .= $this->renderNode( $child );
-            }
-            $output .= '</ul>';
+	function display($tpl = null)
+	{
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+
+		// we need to add these paths so the component can work in both site and administrator
+		$this->addTemplatePath( dirname(__FILE__) . '/tmpl' );
+
+		// client information (site, administrator, ... )
+		jimport( 'joomla.application.helper' );
+		$client = JApplicationHelper::getClientInfo($mainframe->getClientID());
+
+		// make sure we only show the component
+		JRequest::setVar( 'tmpl', 'component' );
+
+		// render tree and assign to template
+		$tree = $this->renderTree();
+		$this->assignRef('tree', $tree );
+
+		$this->assignRef(	'application',	$client->name );
+		$this->assign(		'version',			DUMP_VERSION );
+		$this->assign(		'closebutton',		JRequest::getInt( 'closebutton', 1 ) );
+
+		parent::display($tpl);
+	}
+
+	function & renderTree() {
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+
+		$output = '';
+
+		// get the nodes from the model
+		$nodes = $this->get('nodes');
+
+		// render the nodes to <ul><li...
+		foreach ( $nodes as $node ) {
+			$output .= $this->renderNode( $node );
+		}
+		return $output;
+	}
+
+	function renderNode( & $node ) {
+		switch ( $node['type'] ) {
+			case 'object':
+			case 'array':
+				return $this->renderObjArray( $node );
+				break;
+			case 'integer':
+			case 'float':
+			case 'double':
+				return $this->renderNumber( $node );
+				break;
+			case 'string':
+				return $this->renderString( $node );
+				break;
+			case 'null':
+			case 'resource':
+				return $this->renderNull( $node );
+				break;
+			case 'boolean':
+				return $this->renderBoolean( $node );
+				break;
+			case 'method':
+				return $this->renderMethod( $node );
+				break;
+			case 'methods':
+			case 'properties':
+				return $this->renderMethProp( $node );
+				break;
+			case 'message':
+				return $this->renderMessage( $node );
+				break;
+			default:
+				return $this->renderObjArray( $node );
+				break;
+		}
+	}
+
+	function renderObjArray( & $node ) {
+		global $node_id;
+
+
+
+		$children = count( $node['children'] );
+
+		$output = '';
+
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="a' . ++$node_id . '">' ;
+		$output .= '<span class="dumpType"> [';
+		$output .= ( isset( $node['classname'] ) ? $node['classname'] . ' ' : '' );
+		$output .= $node['type'];
+		$output .= ']</span> ';
+
+		$output .= $node['name'];
+		$output .= $this->renderSource( $node );
+
+
+
+		$output .= $children ? '' : ' = <i>(empty)</i>';
+		$output .= '</a>';
+
+		if ( $children ) {
+			$output .= '<ul>';
+			foreach( $node['children'] as $child ) {
+				$output .= $this->renderNode( $child );
+			}
+			$output .= '</ul>';
 
-        }
-        $output .= '</li>';
+		}
+		$output .= '</li>';
 
-        return $output;
-    }
+		return $output;
+	}
 
-    function renderNull( & $node ) {
-        global $node_id;
+	function renderNull( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' ;
-        $output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
-        $output .= $node['name'];
-        $output .= $this->renderSource( $node );
-        $output .= '</a>';
-        $output .= '</li>';
-        return $output;
-    }
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' ;
+		$output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
+		$output .= $node['name'];
+		$output .= $this->renderSource( $node );
+		$output .= '</a>';
+		$output .= '</li>';
+		return $output;
+	}
 
 
-    function renderNumber( & $node ) {
-        global $node_id;
+	function renderNumber( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' ;
-        $output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
-        $output .= $node['name'];
-        $output .= ' = ' . $node['value'];
-        $output .= $this->renderSource( $node );
-        $output .= '</a>';
-        $output .= '</li>';
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' ;
+		$output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
+		$output .= $node['name'];
+		$output .= ' = ' . $node['value'];
+		$output .= $this->renderSource( $node );
+		$output .= '</a>';
+		$output .= '</li>';
 
-        return $output;
+		return $output;
 
-    }
+	}
 
-    function renderBoolean( & $node ) {
-        global $node_id;
+	function renderBoolean( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' ;
-        $output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
-        $output .= $node['name'];
-        $output .= $this->renderSource( $node );
-        $output .= ' = ' . ( $node['value'] ? 'TRUE' : 'FALSE' );
-        $output .= $this->renderSource( $node );
-        $output .= '</a>';
-        $output .= '</li>';
-        return $output;
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' ;
+		$output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
+		$output .= $node['name'];
+		$output .= $this->renderSource( $node );
+		$output .= ' = ' . ( $node['value'] ? 'TRUE' : 'FALSE' );
+		$output .= $this->renderSource( $node );
+		$output .= '</a>';
+		$output .= '</li>';
+		return $output;
 
-    }
+	}
 
-    function renderString( & $node ) {
-        global $node_id;
+	function renderString( & $node ) {
+		global $node_id;
 
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' ;
-        $output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
-        $output .= $node['name'];
-        $output .= ' = "' . nl2br(htmlspecialchars( $node['value'] , ENT_QUOTES ) ). '"';
-        if ( isset($node['length']) ) { $output .= ' <span class="dumpString">(Length = '.intval($node['length']).')</span>'; }
-        $output .= $this->renderSource( $node );
-        $output .= '</a>';
-        $output .= '</li>';
-        return $output;
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' ;
+		$output .= '<span class="dumpType"> ['. $node['type'] . ']</span> ';
+		$output .= $node['name'];
+		$output .= ' = "' . nl2br(htmlspecialchars( $node['value'] , ENT_QUOTES ) ). '"';
+		if ( isset($node['length']) ) { $output .= ' <span class="dumpString">(Length = '.intval($node['length']).')</span>'; }
+		$output .= $this->renderSource( $node );
+		$output .= '</a>';
+		$output .= '</li>';
+		return $output;
 
-    }
+	}
 
-    function renderMessage( & $node ) {
-        global $node_id;
+	function renderMessage( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' ;
-        $output .= '<i>'.$node['value'].'</i>';
-        $output .= $this->renderSource( $node );
-        $output .= '</a>';
-        $output .= '</li>';
-        return $output;
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' ;
+		$output .= '<i>'.$node['value'].'</i>';
+		$output .= $this->renderSource( $node );
+		$output .= '</a>';
+		$output .= '</li>';
+		return $output;
 
-    }
+	}
 
-    function renderMethod( & $node ) {
-        global $node_id;
+	function renderMethod( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' . $node['name'] . '</a>';
-        $output .= '</li>';
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' . $node['name'] . '</a>';
+		$output .= '</li>';
 
-        return $output;
+		return $output;
 
-    }
-    function renderMethProp( & $node ) {
-        global $node_id;
+	}
+	function renderMethProp( & $node ) {
+		global $node_id;
 
-        $output = '';
+		$output = '';
 
-        $output .= '<li class="' . $node['type'] . '.gif">';
-        $output .= '<a href="#" id="node_' . ++$node_id . '">' . $node['name'] . '</a>';
+		$output .= '<li class="' . $node['type'] . '.gif">';
+		$output .= '<a href="#" id="node_' . ++$node_id . '">' . $node['name'] . '</a>';
 
-        if ( count( $node['children'] ) ) {
-            $output .= '<ul>';
-            foreach( $node['children'] as $child ) {
-                $output .= $this->renderNode( $child );
-            }
-            $output .= '</ul>';
-        }
-        $output .= '</li>';
+		if ( count( $node['children'] ) ) {
+			$output .= '<ul>';
+			foreach( $node['children'] as $child ) {
+				$output .= $this->renderNode( $child );
+			}
+			$output .= '</ul>';
+		}
+		$output .= '</li>';
 
 
 
 
-        return $output;
+		return $output;
 
 
-    }
+	}
 
-    function & renderSource( & $node ) {
-        $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+	function & renderSource( & $node ) {
+		$mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-        $params   = JComponentHelper::getParams('com_dump');
+		$params   = JComponentHelper::getParams('com_dump');
 
-        $output = '';
+		$output = '';
 
-        if ($node['source'] && $params->get('showOrigin', 1))
-        {
-            // next line doesn't work - bug in J?
-            //$output .=  JCommonHTML::ToolTip($node['source'], 'Source');
+		if ($node['source'] && $params->get('showOrigin', 1))
+		{
+			// next line doesn't work - bug in J?
+			//$output .=  JCommonHTML::ToolTip($node['source'], 'Source');
 
-            $tooltip  = '<span class="tool-title">Source</span><br />';
-            $tooltip .= '<span class="tool-text">' . $node['source'] . '</span>';
-            $tooltip  = htmlspecialchars($tooltip);
-            $output  .= '&nbsp;<span class="hasTip" width="600px" title="'.$tooltip.'"><img src="'.DUMP_URL.'assets/images/content.png" alt="Tooltip" border="0" width="12" height="12" /></span>';
+			$tooltip  = '<span class="tool-title">Source</span><br />';
+			$tooltip .= '<span class="tool-text">' . $node['source'] . '</span>';
+			$tooltip  = htmlspecialchars($tooltip);
+			$output  .= '&nbsp;<span class="hasTip" width="600px" title="'.$tooltip.'"><img src="'.DUMP_URL.'assets/images/content.png" alt="Tooltip" border="0" width="12" height="12" /></span>';
 
-        }
+		}
 
-        return $output;
-    }
+		return $output;
+	}
 }

--- a/src/components/com_dump/views/tree/metadata.xml
+++ b/src/components/com_dump/views/tree/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-    <view title="Dump Tree">
-        <message>
-            <![CDATA[This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.]]>
-        </message>
-    </view>
+	<view title="Dump Tree">
+		<message>
+			<![CDATA[This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.]]>
+		</message>
+	</view>
 </metadata>

--- a/src/components/com_dump/views/tree/tmpl/default.xml
+++ b/src/components/com_dump/views/tree/tmpl/default.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-    <layout title="Dump Tree">
-        <message>
-            <![CDATA[This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.]]>
-        </message>
-    </layout>
-    <state>
-        <name>Dump Tree</name>
-        <description>This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.</description>
-        <params></params>
-        <advanced></advanced>
-    </state>
+	<layout title="Dump Tree">
+		<message>
+			<![CDATA[This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.]]>
+		</message>
+	</layout>
+	<state>
+		<name>Dump Tree</name>
+		<description>This layout shows a DHTML tree with the dumped items. It's best to use this with 'New Window With(out) Browser Navigation'.</description>
+		<params></params>
+		<advanced></advanced>
+	</state>
 </metadata>

--- a/src/pkg_dump.xml
+++ b/src/pkg_dump.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
- <extension type="package" version="1.6" method="upgrade">
+<extension type="package" version="1.6" method="upgrade">
 
 	<name>Dump</name>
 	<author>Mathias Verraes</author>
@@ -10,18 +10,18 @@
 
 	<version>%%VERSION%%</version>
 
- <packagename>dump</packagename>
- <url>https://github.com/mathiasverraes/jdump/</url>
- <packager>Mathias Verraes</packager>
- <packagerurl>https://github.com/mathiasverraes/jdump/</packagerurl>
- <description>J!Dump -- Advanced print_r and var_dump replacer with DHTML tree display.</description>
+	<packagename>dump</packagename>
+	<url>https://github.com/mathiasverraes/jdump/</url>
+	<packager>Mathias Verraes</packager>
+	<packagerurl>https://github.com/mathiasverraes/jdump/</packagerurl>
+	<description>J!Dump -- Advanced print_r and var_dump replacer with DHTML tree display.</description>
 
 <!--
  <update>http://www.updateurl.com/update</update>
 -->
- <scriptfile>pkg_script.php</scriptfile>
-  <files>
-   <file type="plugin" id="dump" group="system">plg_system_dump_v%%VERSION%%.zip</file>
-   <file type="component" id="com_dump" >com_dump_v%%VERSION%%.zip</file>
- </files>
- </extension>
+	<scriptfile>pkg_script.php</scriptfile>
+	<files>
+		<file type="plugin" id="dump" group="system">plg_system_dump_v%%VERSION%%.zip</file>
+		<file type="component" id="com_dump" >com_dump_v%%VERSION%%.zip</file>
+	</files>
+</extension>

--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -15,7 +15,9 @@ if (file_exists(JPATH_ADMINISTRATOR.'/components/com_dump/helper.php'))
 {
 	require_once(JPATH_ADMINISTRATOR.'/components/com_dump/helper.php');
 	require_once(JPATH_ADMINISTRATOR.'/components/com_dump/defines.php');
-} else {
+} 
+else 
+{
 	JError::raiseNotice(20, 'The J!Dump Plugin needs the J!Dump Component to function.');
 }
 

--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -11,7 +11,8 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 jimport( 'joomla.event.helper' );
 
-if( file_exists( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' ) ) {
+if( file_exists( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' ) ) 
+{
 	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' );
 	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/defines.php' );
 } else {
@@ -19,19 +20,24 @@ if( file_exists( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' ) ) {
 }
 
 $version = new JVersion();
-if(!$version->isCompatible('2.5.5')) {
+if(!$version->isCompatible('2.5.5')) 
+{
 	JError::raiseNotice( 20, 'J!Dump requires Joomla 2.5.5 or later. For older Joomla versions, please use https://github.com/downloads/mathiasverraes/jdump/unzip_first_jdump_v2012-10-08.zip');
 }
 
-class plgSystemDump extends JPlugin {
-	function __construct(& $subject, $params) {
+class plgSystemDump extends JPlugin 
+{
+	function __construct(& $subject, $params) 
+	{
 		parent::__construct($subject, $params);
 	}
 
-	function onAfterRender() {
+	function onAfterRender() 
+	{
 	   $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-		if($option == 'com_dump'){
+		if($option == 'com_dump')
+		{
 			return;
 		}
 
@@ -42,7 +48,8 @@ class plgSystemDump extends JPlugin {
 		$userstate = $mainframe->getUserState( 'dump.nodes', array() );
 		$cnt_dumps  = count( $userstate );
 
-		if( $autopopup && $cnt_dumps) {
+		if( $autopopup && $cnt_dumps) 
+		{
 			DumpHelper::showPopup();
 		}
 	}
@@ -83,7 +90,8 @@ function dump( $var = null, $name = '(unknown name)', $type = null, $level = 0 )
  * Shortcut to dump the parameters of a template
  * @param object $var The "$this" object in the template
  */
-function dumpTemplate( $var, $name = false ) {
+function dumpTemplate( $var, $name = false ) 
+{
 	$name = $name ? $name :  $var->template;
 	dump( $var->params->toObject(), "dumpTemplate params : ".$name);
 }
@@ -92,14 +100,16 @@ function dumpTemplate( $var, $name = false ) {
  * Shortcut to dump a message
  * @param string $msg The message
  */
-function dumpMessage( $msg = '(Empty message)' ) {
+function dumpMessage( $msg = '(Empty message)' ) 
+{
 	dump( $msg, null, 'message', 0 );
 }
 
 /**
  * Shortcut to dump system information
  */
-function dumpSysinfo() {
+function dumpSysinfo() 
+{
 	require_once JPATH_ADMINISTRATOR.'/components/com_dump/sysinfo.php';
 	$sysinfo = new DumpSysinfo();
 	dump( $sysinfo->data, 'System Information');

--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -12,40 +12,40 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 jimport( 'joomla.event.helper' );
 
 if( file_exists( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' ) ) {
-    require_once( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' );
-    require_once( JPATH_ADMINISTRATOR.'/components/com_dump/defines.php' );
+	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' );
+	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/defines.php' );
 } else {
-    JError::raiseNotice( 20, 'The J!Dump Plugin needs the J!Dump Component to function.' );
+	JError::raiseNotice( 20, 'The J!Dump Plugin needs the J!Dump Component to function.' );
 }
 
 $version = new JVersion();
 if(!$version->isCompatible('2.5.5')) {
-    JError::raiseNotice( 20, 'J!Dump requires Joomla 2.5.5 or later. For older Joomla versions, please use https://github.com/downloads/mathiasverraes/jdump/unzip_first_jdump_v2012-10-08.zip');
+	JError::raiseNotice( 20, 'J!Dump requires Joomla 2.5.5 or later. For older Joomla versions, please use https://github.com/downloads/mathiasverraes/jdump/unzip_first_jdump_v2012-10-08.zip');
 }
 
 class plgSystemDump extends JPlugin {
-    function __construct(& $subject, $params) {
-        parent::__construct($subject, $params);
-    }
+	function __construct(& $subject, $params) {
+		parent::__construct($subject, $params);
+	}
 
-    function onAfterRender() {
-       $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
+	function onAfterRender() {
+	   $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-        if($option == 'com_dump'){
-            return;
-        }
+		if($option == 'com_dump'){
+			return;
+		}
 
-        // settings from config.xml
-        $dumpConfig = JComponentHelper::getParams( 'com_dump' );
-        $autopopup  = $dumpConfig->get( 'autopopup', 1 );
+		// settings from config.xml
+		$dumpConfig = JComponentHelper::getParams( 'com_dump' );
+		$autopopup  = $dumpConfig->get( 'autopopup', 1 );
 
-        $userstate = $mainframe->getUserState( 'dump.nodes', array() );
-        $cnt_dumps  = count( $userstate );
+		$userstate = $mainframe->getUserState( 'dump.nodes', array() );
+		$cnt_dumps  = count( $userstate );
 
-        if( $autopopup && $cnt_dumps) {
-            DumpHelper::showPopup();
-        }
-    }
+		if( $autopopup && $cnt_dumps) {
+			DumpHelper::showPopup();
+		}
+	}
 }
 
 
@@ -56,27 +56,27 @@ class plgSystemDump extends JPlugin {
  */
 function dump( $var = null, $name = '(unknown name)', $type = null, $level = 0 )
 {
-    $mainframe = JFactory::getApplication(); 
-    $option    = JRequest::getCmd('option');
+	$mainframe = JFactory::getApplication(); 
+	$option    = JRequest::getCmd('option');
 
-    require_once JPATH_ADMINISTRATOR.'/components/com_dump/node.php';
+	require_once JPATH_ADMINISTRATOR.'/components/com_dump/node.php';
 
 		$source = '';
 		if (function_exists('debug_backtrace'))
 		{
 			$trace = debug_backtrace();
 			$source = DumpHelper::getSourceFunction($trace) 
-			        . DumpHelper::getSourcePath($trace);
+					. DumpHelper::getSourcePath($trace);
 		}
 
-    // create a new node array
-    $node           = DumpNode::getNode( $var, $name, $type, $level, $source );
-    //get the current userstate
-    $userstate      = $mainframe->getUserState( 'dump.nodes' );
-    // append the node to the array
-    $userstate[]    = $node;
-    // set the userstate to the new array
-    $mainframe->setUserState( 'dump.nodes', $userstate );
+	// create a new node array
+	$node           = DumpNode::getNode( $var, $name, $type, $level, $source );
+	//get the current userstate
+	$userstate      = $mainframe->getUserState( 'dump.nodes' );
+	// append the node to the array
+	$userstate[]    = $node;
+	// set the userstate to the new array
+	$mainframe->setUserState( 'dump.nodes', $userstate );
 }
 
 /**
@@ -84,8 +84,8 @@ function dump( $var = null, $name = '(unknown name)', $type = null, $level = 0 )
  * @param object $var The "$this" object in the template
  */
 function dumpTemplate( $var, $name = false ) {
-    $name = $name ? $name :  $var->template;
-    dump( $var->params->toObject(), "dumpTemplate params : ".$name);
+	$name = $name ? $name :  $var->template;
+	dump( $var->params->toObject(), "dumpTemplate params : ".$name);
 }
 
 /**
@@ -93,16 +93,16 @@ function dumpTemplate( $var, $name = false ) {
  * @param string $msg The message
  */
 function dumpMessage( $msg = '(Empty message)' ) {
-    dump( $msg, null, 'message', 0 );
+	dump( $msg, null, 'message', 0 );
 }
 
 /**
  * Shortcut to dump system information
  */
 function dumpSysinfo() {
-    require_once JPATH_ADMINISTRATOR.'/components/com_dump/sysinfo.php';
-    $sysinfo = new DumpSysinfo();
-    dump( $sysinfo->data, 'System Information');
+	require_once JPATH_ADMINISTRATOR.'/components/com_dump/sysinfo.php';
+	$sysinfo = new DumpSysinfo();
+	dump( $sysinfo->data, 'System Information');
 }
 
 /**

--- a/src/plugins/system/dump/dump.php
+++ b/src/plugins/system/dump/dump.php
@@ -11,18 +11,18 @@ defined( '_JEXEC' ) or die( 'Restricted access' );
 
 jimport( 'joomla.event.helper' );
 
-if( file_exists( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' ) ) 
+if (file_exists(JPATH_ADMINISTRATOR.'/components/com_dump/helper.php')) 
 {
-	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/helper.php' );
-	require_once( JPATH_ADMINISTRATOR.'/components/com_dump/defines.php' );
+	require_once(JPATH_ADMINISTRATOR.'/components/com_dump/helper.php');
+	require_once(JPATH_ADMINISTRATOR.'/components/com_dump/defines.php');
 } else {
-	JError::raiseNotice( 20, 'The J!Dump Plugin needs the J!Dump Component to function.' );
+	JError::raiseNotice(20, 'The J!Dump Plugin needs the J!Dump Component to function.');
 }
 
 $version = new JVersion();
-if(!$version->isCompatible('2.5.5')) 
+if (!$version->isCompatible('2.5.5')) 
 {
-	JError::raiseNotice( 20, 'J!Dump requires Joomla 2.5.5 or later. For older Joomla versions, please use https://github.com/downloads/mathiasverraes/jdump/unzip_first_jdump_v2012-10-08.zip');
+	JError::raiseNotice(20, 'J!Dump requires Joomla 2.5.5 or later. For older Joomla versions, please use https://github.com/downloads/mathiasverraes/jdump/unzip_first_jdump_v2012-10-08.zip');
 }
 
 class plgSystemDump extends JPlugin 
@@ -36,7 +36,7 @@ class plgSystemDump extends JPlugin
 	{
 	   $mainframe = JFactory::getApplication(); $option = JRequest::getCmd('option');
 
-		if($option == 'com_dump')
+		if ($option == 'com_dump')
 		{
 			return;
 		}
@@ -46,7 +46,7 @@ class plgSystemDump extends JPlugin
 		$autopopup  = $dumpConfig->get( 'autopopup', 1 );
 
 		$userstate = $mainframe->getUserState( 'dump.nodes', array() );
-		$cnt_dumps  = count( $userstate );
+		$cnt_dumps  = count($userstate);
 
 		if( $autopopup && $cnt_dumps) 
 		{
@@ -61,7 +61,7 @@ class plgSystemDump extends JPlugin
  * @param mixed $var The variable you want to dump
  * @param mixed $name The name of the variable you want to dump
  */
-function dump( $var = null, $name = '(unknown name)', $type = null, $level = 0 )
+function dump($var = null, $name = '(unknown name)', $type = null, $level = 0)
 {
 	$mainframe = JFactory::getApplication(); 
 	$option    = JRequest::getCmd('option');
@@ -77,32 +77,32 @@ function dump( $var = null, $name = '(unknown name)', $type = null, $level = 0 )
 		}
 
 	// create a new node array
-	$node           = DumpNode::getNode( $var, $name, $type, $level, $source );
+	$node           = DumpNode::getNode($var, $name, $type, $level, $source);
 	//get the current userstate
-	$userstate      = $mainframe->getUserState( 'dump.nodes' );
+	$userstate      = $mainframe->getUserState('dump.nodes');
 	// append the node to the array
 	$userstate[]    = $node;
 	// set the userstate to the new array
-	$mainframe->setUserState( 'dump.nodes', $userstate );
+	$mainframe->setUserState('dump.nodes', $userstate);
 }
 
 /**
  * Shortcut to dump the parameters of a template
  * @param object $var The "$this" object in the template
  */
-function dumpTemplate( $var, $name = false ) 
+function dumpTemplate($var, $name = false) 
 {
 	$name = $name ? $name :  $var->template;
-	dump( $var->params->toObject(), "dumpTemplate params : ".$name);
+	dump($var->params->toObject(), "dumpTemplate params : ".$name);
 }
 
 /**
  * Shortcut to dump a message
  * @param string $msg The message
  */
-function dumpMessage( $msg = '(Empty message)' ) 
+function dumpMessage($msg = '(Empty message)') 
 {
-	dump( $msg, null, 'message', 0 );
+	dump($msg, null, 'message', 0);
 }
 
 /**
@@ -143,7 +143,7 @@ function dumpTraceBuild($trace)
 
 	array_shift($trace);
 	
-	if (count($trace)>0)
+	if (count($trace) > 0)
 		$ret['backtrace'] = dumpTraceBuild($trace);
 
 	return $ret;


### PR DESCRIPTION
Conforms code to [Joomla's coding style guide](https://developer.joomla.org/coding-standards/php-code.html) in order to maintain style consistency across repository. More specifically the following changes:

1. All files using tabs rather spaces
2. `{` in control structures on a new line
 ``` php
function foo()
{
``` 
3. No spaces after `(` and before `)` in function/control structure arguments
``` php
if ($foo && $bar)
```

The reason Joomla's standard was chosen for this merge request was due to part of the repo already seemingly conforming to these standards. 

I am open to any code style changes, the main purpose was an attempt to create consistency. 